### PR TITLE
feat: auto-correct queries on missing columns

### DIFF
--- a/src/ai/sql_agent.py
+++ b/src/ai/sql_agent.py
@@ -163,14 +163,38 @@ QUERY SQL:"""
         else:
             # Se não conseguiu extrair, retorna a resposta original limpa
             return response.strip()
-    
+
+    def _fix_sql_query(self, sql_query: str, error_msg: str) -> Optional[str]:
+        """Tenta corrigir uma query SQL com base no schema e na mensagem de erro"""
+
+        schema = self.get_database_schema()
+        prompt = f"""A seguinte query SQL apresentou erro:
+{sql_query}
+
+ERRO: {error_msg}
+
+Considerando o schema abaixo, corrija a query mantendo o mesmo objetivo.
+{schema}
+
+QUERY CORRIGIDA:"""
+
+        try:
+            response = ollama.chat(
+                model=self.ollama_model,
+                messages=[{'role': 'user', 'content': prompt}]
+            )
+            corrected = self._clean_sql_response(response['message']['content'].strip())
+            return corrected
+        except Exception:
+            return None
+
     def process_query(self, user_input: str, chat_history: list = None) -> Dict[str, Any]:
         """Processa uma consulta SQL completa"""
-        
+
         try:
             # Verificar se é uma query pré-definida
             predefined_query = self.check_predefined_queries(user_input)
-            
+
             if predefined_query and predefined_query in PREDEFINED_QUERIES:
                 sql_query = PREDEFINED_QUERIES[predefined_query]
                 query_source = 'predefined'
@@ -178,13 +202,25 @@ QUERY SQL:"""
                 # Gerar query usando IA
                 sql_query = self.generate_sql_query(user_input, chat_history)
                 query_source = 'generated'
-            
-            # Executar a query
-            results, columns = self.db.execute_query(sql_query)
-            
+
+            try:
+                # Executar a query
+                results, columns = self.db.execute_query(sql_query)
+            except Exception as e:
+                if 'no such column' in str(e).lower():
+                    corrected = self._fix_sql_query(sql_query, str(e))
+                    if corrected:
+                        sql_query = corrected
+                        query_source = 'corrected'
+                        results, columns = self.db.execute_query(sql_query)
+                    else:
+                        raise
+                else:
+                    raise
+
             # Gerar resposta em linguagem natural
             response_text = self._generate_response_text(user_input, results, columns, sql_query)
-            
+
             return {
                 'response': response_text,
                 'sql_query': sql_query,
@@ -195,7 +231,7 @@ QUERY SQL:"""
                     'row_count': len(results)
                 }
             }
-            
+
         except Exception as e:
             return {
                 'response': f'Desculpe, ocorreu um erro ao executar a consulta SQL: {str(e)}',


### PR DESCRIPTION
## Summary
- retry SQL queries by consulting schema when a `no such column` error occurs
- add internal `_fix_sql_query` helper to request a corrected query from the LLM

## Testing
- `python -m py_compile src/ai/sql_agent.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68adc498f18c832e87abfdb2b3c68967